### PR TITLE
More lenient presence check post-join and shutdown edge-case handling

### DIFF
--- a/server/call/operator.py
+++ b/server/call/operator.py
@@ -36,11 +36,6 @@ class Operator():
         # Create a new session
         session = Session(self._config, room_duration_mins, room_url)
         self._sessions.append(session)
-
-        print("active threads:", threading.active_count())
-        for thread in threading.enumerate():
-            print(thread.native_id, thread.name)
-
         return session.room_url
 
     def query_assistant(self, room_url: str, custom_query=None) -> str:
@@ -77,7 +72,4 @@ class Operator():
             if session.is_destroyed:
                 print("Removing destroyed session:", session.room_url)
                 self._sessions.remove(session)
-                print("active threads:", threading.active_count())
-                for thread in threading.enumerate():
-                    print(thread.native_id, thread.name)
         return False

--- a/server/call/operator.py
+++ b/server/call/operator.py
@@ -36,6 +36,11 @@ class Operator():
         # Create a new session
         session = Session(self._config, room_duration_mins, room_url)
         self._sessions.append(session)
+
+        print("active threads:", threading.active_count())
+        for thread in threading.enumerate():
+            print(thread.native_id, thread.name)
+
         return session.room_url
 
     def query_assistant(self, room_url: str, custom_query=None) -> str:
@@ -72,4 +77,7 @@ class Operator():
             if session.is_destroyed:
                 print("Removing destroyed session:", session.room_url)
                 self._sessions.remove(session)
+                print("active threads:", threading.active_count())
+                for thread in threading.enumerate():
+                    print(thread.native_id, thread.name)
         return False

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -309,18 +309,15 @@ class Session(EventHandler):
         self._logger.info("Bot joined meeting %s", self._room.url)
         self._id = join_data["participants"]["local"]["id"]
 
-        # If there is no one in the call, someone must have already left
-        # Start shutdown process in that case.
-        if self.maybe_start_shutdown():
-            # If starting shutdown, don't bother with the rest
-            # of the join-related operations
-            return
-
         self._logger.info("Starting transcription1 %s", self._room.url)
         self._call_client.start_transcription()
         self._logger.info("Started transcription1 %s", self._room.url)
         self._call_client.set_user_name("Daily AI Assistant")
         self.set_session_data(self._room.name, self._id)
+
+        # If there is no one in the call, someone must have already left
+        # Start shutdown process in that case.
+        self.maybe_start_shutdown()
 
     def on_error(self, message):
         """Callback invoked when an error is received."""

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -309,14 +309,14 @@ class Session(EventHandler):
         self._logger.info("Bot joined meeting %s", self._room.url)
         self._id = join_data["participants"]["local"]["id"]
 
-        self._logger.info("Starting transcription1 %s", self._room.url)
+        self._logger.info("Starting transcription %s", self._room.url)
         self._call_client.start_transcription()
-        self._logger.info("Started transcription1 %s", self._room.url)
         self._call_client.set_user_name("Daily AI Assistant")
         self.set_session_data(self._room.name, self._id)
 
-        # If there is no one in the call, someone must have already left
-        # Start shutdown process in that case.
+        # If there is no other user in the call, someone must have already left
+        # Start shutdown process in that case (the shutdown will be cancelled if
+        # a participant joined event is subsequently received)
         self.maybe_start_shutdown()
 
     def on_error(self, message):
@@ -383,7 +383,7 @@ class Session(EventHandler):
         """Checks if the session should be shut down, and if so, starts the shutdown process."""
         count = self.get_participant_count()
         self._logger.info(
-            "Participant count1: %s", count)
+            "Participant count: %s", count)
 
         # If there is at least one present participant, do nothing.
         if count > 1:

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -314,9 +314,9 @@ class Session(EventHandler):
         self._call_client.set_user_name("Daily AI Assistant")
         self.set_session_data(self._room.name, self._id)
 
-        # If there is no other user in the call, someone must have already left
-        # Start shutdown process in that case (the shutdown will be cancelled if
-        # a participant joined event is subsequently received)
+        # Check whether the bot is actually the only one in the call, in which case
+        # the shutdown timer should start. The shutdown will be cancelled if
+        # daily-python detects someone new joining.
         self.maybe_start_shutdown()
 
     def on_error(self, message):

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -282,6 +282,7 @@ class Session(EventHandler):
             self._logger.error("Failed to send app message: %s", error)
 
     def on_left_meeting(self, _, error: str = None):
+        """Cancels any ongoing shutdown timer and marks this session as destroyed"""
         if error:
             self._logger.error(
                 "Encountered error while leaving meeting: %s", error)
@@ -374,6 +375,7 @@ class Session(EventHandler):
         self.maybe_start_shutdown()
 
     def on_call_state_updated(self, state: Mapping[str, Any]) -> None:
+        """Invoked when the Daily call state has changed"""
         self._logger.info("Call state updated for session %s: %s", self._room.url, state)
         if state == "left" and not self._is_destroyed:
             self._logger.info("Call state left, destroying immediately")
@@ -427,6 +429,7 @@ class Session(EventHandler):
         self._call_client.leave(self.on_left_meeting)
 
     def cancel_shutdown_timer(self):
+        """Cancels the live shutdown timer"""
         self._shutdown_timer.cancel()
         self._shutdown_timer = None
 
@@ -437,7 +440,7 @@ class Session(EventHandler):
         return headers
 
     def create_logger(self, name) -> Logger:
-        # Create a logger
+        """Creates a logger for this session"""
         logger = logging.getLogger(name)
         logger.setLevel(logging.DEBUG)
 

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -385,7 +385,7 @@ class Session(EventHandler):
 
     def maybe_start_shutdown(self) -> bool:
         """Checks if the session should be shut down, and if so, starts the shutdown process."""
-        count = self._call_client.participant_counts()['present']
+        count = self.get_participant_count()
         self._logger.info(
             "Participant count: %s", count)
 

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -317,7 +317,9 @@ class Session(EventHandler):
             return
 
         time.sleep(5)
+        self._logger.info("Starting transcription %s", self._room.url)
         self._call_client.start_transcription()
+        self._logger.info("Started transcription %s", self._room.url)
         self._call_client.set_user_name("Daily AI Assistant")
         self.set_session_data(self._room.name, self._id)
 

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -55,7 +55,7 @@ class Session(EventHandler):
 
     # Daily-related properties
     _id: str | None
-    _call_client: CallClient
+    _call_client: CallClient | None
     _room: Room
 
     # Shutdown-related properties
@@ -315,6 +315,8 @@ class Session(EventHandler):
             # If starting shutdown, don't bother with the rest
             # of the join-related operations
             return
+
+        time.sleep(5)
         self._call_client.start_transcription()
         self._call_client.set_user_name("Daily AI Assistant")
         self.set_session_data(self._room.name, self._id)

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -423,6 +423,7 @@ class Session(EventHandler):
             f"Session {self._id} shutting down. Active threads: %s",
             threading.active_count())
 
+        self.cancel_shutdown_timer()
         self._call_client.leave(self.on_left_meeting)
 
     def cancel_shutdown_timer(self):

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -316,10 +316,9 @@ class Session(EventHandler):
             # of the join-related operations
             return
 
-        time.sleep(5)
-        self._logger.info("Starting transcription %s", self._room.url)
+        self._logger.info("Starting transcription1 %s", self._room.url)
         self._call_client.start_transcription()
-        self._logger.info("Started transcription %s", self._room.url)
+        self._logger.info("Started transcription1 %s", self._room.url)
         self._call_client.set_user_name("Daily AI Assistant")
         self.set_session_data(self._room.name, self._id)
 
@@ -387,7 +386,7 @@ class Session(EventHandler):
         """Checks if the session should be shut down, and if so, starts the shutdown process."""
         count = self.get_participant_count()
         self._logger.info(
-            "Participant count: %s", count)
+            "Participant count1: %s", count)
 
         # If there is at least one present participant, do nothing.
         if count > 1:

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -374,7 +374,7 @@ class Session(EventHandler):
         self.maybe_start_shutdown()
 
     def on_call_state_updated(self, state: Mapping[str, Any]) -> None:
-        self._logger.info("Call state updated for session %s: %s", self._id, state)
+        self._logger.info("Call state updated for session %s: %s", self._room.url, state)
         if state == "left" and not self._is_destroyed:
             self._logger.info("Call state left, destroying immediately")
             self.on_left_meeting(None)


### PR DESCRIPTION
This PR:

* Moves the aggressive presence check when the bot joins, as the presence is not currently reliable. Instead of earlying-out before starting any transcription or other operations if not enough users are in the call, we go ahead and start running everything and then begin a shutdown timer IF not enough people appear to be in the call. This gives call client state time to catch up

* Adds handling for the bot being kicked out (for example, in case the room expires) instead of invoking `leave()` on its own. Adds accompanying handling for shutdown timers to avoid duplicate shutdown operations if the bot is both kicked out _and_ calls leave.