### PR TITLE
Go back to client-side counts for now..

### DIFF
--- a/server/call/session.py
+++ b/server/call/session.py
@@ -383,7 +383,7 @@ class Session(EventHandler):
 
     def maybe_start_shutdown(self) -> bool:
         """Checks if the session should be shut down, and if so, starts the shutdown process."""
-        count = self.get_participant_count()
+        count = self._call_client.participant_counts()['present']
         self._logger.info(
             "Participant count: %s", count)
 


### PR DESCRIPTION
This is likely to still not provide an accurate count (as we saw yesterday), but coupled with the PR from yesterday which also made the startup logic more lenient, I hope this will give us _better_ behavior between what we saw then (bot leaving the meeting immediately due to incorrect count) and today (bot never leaving due to incorrect count). 

I've already filed a Linear ticket to investigate the count issue itself, so once we have more info on that we can follow up with whatever final approach is recommended.