### PR TITLE
Lock lists to avoid read/writing from different thread, and run OpenAI requests in thread pool executor

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install -r server/requirements.txt
 COPY . /app/server
 EXPOSE 80
 
-CMD quart --app server/main.py --debug run --host=0.0.0.0 --port 80
+CMD quart --app server/main.py run --host=0.0.0.0 --port 80

--- a/server/call/operator.py
+++ b/server/call/operator.py
@@ -10,13 +10,15 @@ from server.call.session import Session
 
 class Operator():
     _config: Config
-    _sessions: list[Session] = []
+    _sessions: list[Session]
     _is_shutting_down: bool
-    _lock = threading.Lock()
+    _lock: threading.Lock
 
     def __init__(self, config: Config):
         self._config = config
         self._is_shutting_down = False
+        self._lock = threading.Lock()
+        self._sessions = []
         Daily.init()
 
         t = threading.Thread(target=self.cleanup)

--- a/server/call/operator.py
+++ b/server/call/operator.py
@@ -12,6 +12,7 @@ class Operator():
     _config: Config
     _sessions: list[Session] = []
     _is_shutting_down: bool
+    _lock = threading.Lock()
 
     def __init__(self, config: Config):
         self._config = config
@@ -35,7 +36,8 @@ class Operator():
 
         # Create a new session
         session = Session(self._config, room_duration_mins, room_url)
-        self._sessions.append(session)
+        with self._lock:
+            self._sessions.append(session)
         return session.room_url
 
     def query_assistant(self, room_url: str, custom_query=None) -> str:
@@ -71,5 +73,6 @@ class Operator():
         for session in self._sessions:
             if session.is_destroyed:
                 print("Removing destroyed session:", session.room_url)
-                self._sessions.remove(session)
+                with self._lock:
+                    self._sessions.remove(session)
         return False

--- a/server/call/operator.py
+++ b/server/call/operator.py
@@ -45,12 +45,15 @@ class Operator():
 
     def query_assistant(self, room_url: str, custom_query=None) -> str:
         """Queries the assistant for the provided room URL."""
-        with self._lock:
-            for s in self._sessions:
-                if s.room_url == room_url and not s.is_destroyed:
-                    return s.query_assistant(custom_query=custom_query)
-            raise Exception(
-                f"Requested room URL {room_url} not found in active sessions")
+        self._lock.acquire()
+        for s in self._sessions:
+            if s.room_url == room_url and not s.is_destroyed:
+                self._lock.release()
+                return s.query_assistant(custom_query=custom_query)
+            
+        self._lock.release()
+        raise Exception(
+            f"Requested room URL {room_url} not found in active sessions")
 
     def shutdown(self):
         """Shuts down all active sessions"""

--- a/server/call/operator.py
+++ b/server/call/operator.py
@@ -50,7 +50,7 @@ class Operator():
             if s.room_url == room_url and not s.is_destroyed:
                 self._lock.release()
                 return await s.query_assistant(custom_query=custom_query)
-            
+
         self._lock.release()
         raise Exception(
             f"Requested room URL {room_url} not found in active sessions")

--- a/server/call/operator.py
+++ b/server/call/operator.py
@@ -43,13 +43,13 @@ class Operator():
             self._sessions.append(session)
         return session.room_url
 
-    def query_assistant(self, room_url: str, custom_query=None) -> str:
+    async def query_assistant(self, room_url: str, custom_query=None) -> str:
         """Queries the assistant for the provided room URL."""
         self._lock.acquire()
         for s in self._sessions:
             if s.room_url == room_url and not s.is_destroyed:
                 self._lock.release()
-                return s.query_assistant(custom_query=custom_query)
+                return await s.query_assistant(custom_query=custom_query)
             
         self._lock.release()
         raise Exception(

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -218,10 +218,10 @@ class Session(EventHandler):
         res = requests.post(url,
                             headers=headers,
                             json={'properties':
-                                      {'room_name': room_name,
-                                       'is_owner': True,
-                                       'exp': token_expiry,
-                                       }})
+                                  {'room_name': room_name,
+                                   'is_owner': True,
+                                   'exp': token_expiry,
+                                   }})
 
         if not res.ok:
             raise Exception(
@@ -232,7 +232,7 @@ class Session(EventHandler):
         return meeting_token
 
     async def query_assistant(self, recipient_session_id: str = None,
-                        custom_query: str = None) -> [str | Future]:
+                              custom_query: str = None) -> [str | Future]:
         """Queries the configured assistant with either the given query, or the
         configured assistant's default"""
 
@@ -290,7 +290,8 @@ class Session(EventHandler):
         # is kicked or leaves for other reasons. Clean up the shutdown timer if
         # that is the case.
         if self._shutdown_timer:
-            self._logger.info("Participant left meeting - cancelling shutdown.")
+            self._logger.info(
+                "Participant left meeting - cancelling shutdown.")
             self.cancel_shutdown_timer()
 
         # Similar to above, if this session has already been destroyed for any other reason,
@@ -340,8 +341,8 @@ class Session(EventHandler):
         self._assistant.register_new_context(text, metadata)
 
     async def on_app_message(self,
-                       message: str,
-                       sender: str):
+                             message: str,
+                             sender: str):
         """Callback invoked when a Daily app message is received."""
         # TODO message appears to be a dict when our docs say str.
         # For now dumping it to a JSON string and parsing it back out,
@@ -375,7 +376,10 @@ class Session(EventHandler):
 
     def on_call_state_updated(self, state: Mapping[str, Any]) -> None:
         """Invoked when the Daily call state has changed"""
-        self._logger.info("Call state updated for session %s: %s", self._room.url, state)
+        self._logger.info(
+            "Call state updated for session %s: %s",
+            self._room.url,
+            state)
         if state == "left" and not self._is_destroyed:
             self._logger.info("Call state left, destroying immediately")
             self.on_left_meeting(None)

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -2,7 +2,6 @@
 This is responsible for all Daily operations."""
 from __future__ import annotations
 
-import asyncio
 import dataclasses
 import json
 import logging

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -231,7 +231,7 @@ class Session(EventHandler):
         meeting_token = res.json()['token']
         return meeting_token
 
-    def query_assistant(self, recipient_session_id: str = None,
+    async def query_assistant(self, recipient_session_id: str = None,
                         custom_query: str = None) -> [str | Future]:
         """Queries the configured assistant with either the given query, or the
         configured assistant's default"""
@@ -252,7 +252,7 @@ class Session(EventHandler):
         if not answer:
             self._logger.info("Querying assistant")
             try:
-                answer = self._assistant.query(custom_query)
+                answer = await self._assistant.query(custom_query)
                 # If there was no custom query provided, save this as cached
                 # summary.
                 if want_cached_summary:
@@ -339,7 +339,7 @@ class Session(EventHandler):
         metadata = [user_name, 'voice', timestamp]
         self._assistant.register_new_context(text, metadata)
 
-    def on_app_message(self,
+    async def on_app_message(self,
                        message: str,
                        sender: str):
         """Callback invoked when a Daily app message is received."""
@@ -359,7 +359,7 @@ class Session(EventHandler):
         # Should probably be limited only to owners
         if bool(data.get("broadcast")):
             recipient = "*"
-        self.query_assistant(recipient, query)
+        await self.query_assistant(recipient, query)
 
     def on_participant_joined(self, participant):
         # As soon as someone joins, stop shutdown process if one is in progress

--- a/server/llm/assistant.py
+++ b/server/llm/assistant.py
@@ -16,5 +16,5 @@ class Assistant(ABC):
         """Registers new context (usually a transcription line)."""
 
     @abstractmethod
-    def query(self, custom_query: str) -> str:
+    async def query(self, custom_query: str) -> str:
         """Runs a query against the assistant and returns the answer."""

--- a/server/llm/openai_assistant.py
+++ b/server/llm/openai_assistant.py
@@ -71,7 +71,8 @@ class OpenAIAssistant(Assistant):
 
         try:
             loop = asyncio.get_event_loop()
-            future = loop.run_in_executor(None, self._make_openai_request, messages)
+            future = loop.run_in_executor(
+                None, self._make_openai_request, messages)
             res = await future
             return res
         except Exception as e:
@@ -86,7 +87,8 @@ class OpenAIAssistant(Assistant):
         content += new_text
         return content
 
-    def _make_openai_request(self, messages: list[ChatCompletionMessageParam]) -> str:
+    def _make_openai_request(
+            self, messages: list[ChatCompletionMessageParam]) -> str:
         """Makes a chat completion request to OpenAI and returns the response."""
         res = self._client.chat.completions.create(
             model=self._model_name,
@@ -98,4 +100,6 @@ class OpenAIAssistant(Assistant):
             if reason == "stop" or reason == "length":
                 answer = choice.message.content
                 return answer
-        raise Exception("No usable choice found in OpenAI response: %s", res.choices)
+        raise Exception(
+            "No usable choice found in OpenAI response: %s",
+            res.choices)

--- a/server/main.py
+++ b/server/main.py
@@ -2,13 +2,17 @@
 import json
 import sys
 import traceback
+from os.path import join, dirname, abspath
 
+from quart.cli import load_dotenv
 from quart_cors import cors
 from quart import Quart, jsonify, Response, request
 
 from server.config import Config
 from server.call.operator import Operator
 
+dotenv_path = join(dirname(dirname(abspath(__file__))), '.env')
+load_dotenv(dotenv_path)
 app = Quart(__name__)
 
 print("Running AI assistant server")
@@ -67,7 +71,7 @@ async def summary():
     if not room_url:
         return process_error('room_url query parameter must be provided', 400)
     try:
-        got_summary = operator.query_assistant(room_url)
+        got_summary = await operator.query_assistant(room_url)
         return jsonify({
             "summary": got_summary
         }), 200
@@ -98,7 +102,7 @@ async def query():
             "Request body must contain a 'room_url' and 'query'", 400)
 
     try:
-        res = operator.query_assistant(room_url, requested_query)
+        res = await operator.query_assistant(room_url, requested_query)
         return jsonify({
             "response": res
         }), 200


### PR DESCRIPTION
This PR adds locks to collections that have a chance of being read and written from different threads at the same time.

Note that this is a simplistic approach for the purpose of the demo; if we want to be fancy we probably want to implement RW locks, but if desired that can be done as a followup to this PR. If optimizing, we might also consider investigating whether it makes sense to batch context updates to avoid potential for many locks while repeatedly updating and querying in close succession.

This PR also runs OpenAI requests in separate threads to avoid blocking the main thread.