### PR TITLE
Some added error reporting

### DIFF
--- a/client/utils/api.js
+++ b/client/utils/api.js
@@ -10,11 +10,11 @@ export const fetchSummary = async (roomUrl) => {
     },
   });
 
+  const body = await response.json();
   if (response.ok) {
-    const body = await response.json();
     return body.summary;
   }
-
+  console.error("Failed to fetch summary: ", body);
   throw new Error();
 };
 
@@ -41,11 +41,11 @@ export const fetchTranscript = async (roomUrl) => {
     }),
   });
 
+  const body = await response.json();
   if (response.ok) {
-    const body = await response.json();
     return body.response;
   }
-
+  console.error("Failed to fetch transcript: ", body);
   throw new Error();
 };
 
@@ -61,10 +61,11 @@ export const fetchQuery = async (roomUrl, query) => {
     }),
   });
 
+  const body = await response.json();
   if (response.ok) {
     const body = await response.json();
     return body.response;
   }
-
-  throw new Error();
+  console.error("Failed to fetch query: ", body);
+  throw new Error()
 };

--- a/server/call/errors.py
+++ b/server/call/errors.py
@@ -1,0 +1,5 @@
+class SessionNotFoundException(Exception):
+    def __init__(self, session_id: str):
+        # Call the base class constructor with the parameters it needs
+        super().__init__(
+            f"Requested session ID {session_id} not found in active sessions")

--- a/server/call/operator.py
+++ b/server/call/operator.py
@@ -4,6 +4,7 @@ import threading
 
 import polling2
 from daily import Daily
+from server.call.errors import SessionNotFoundException
 from server.config import Config
 from server.call.session import Session
 
@@ -52,8 +53,7 @@ class Operator():
                 return await s.query_assistant(custom_query=custom_query)
 
         self._lock.release()
-        raise Exception(
-            f"Requested room URL {room_url} not found in active sessions")
+        raise SessionNotFoundException(room_url)
 
     def shutdown(self):
         """Shuts down all active sessions"""

--- a/server/main.py
+++ b/server/main.py
@@ -7,6 +7,7 @@ from os.path import join, dirname, abspath
 from quart.cli import load_dotenv
 from quart_cors import cors
 from quart import Quart, jsonify, Response, request
+from server.call.errors import SessionNotFoundException
 
 from server.config import Config
 from server.call.operator import Operator
@@ -75,6 +76,9 @@ async def summary():
         return jsonify({
             "summary": got_summary
         }), 200
+    except SessionNotFoundException as e:
+        return process_error(
+            'Requested session not found. Has it been destroyed?', 400, e)
     except Exception as e:
         return process_error('failed to generate meeting summary', 500, e)
 
@@ -106,6 +110,9 @@ async def query():
         return jsonify({
             "response": res
         }), 200
+    except SessionNotFoundException as e:
+        return process_error(
+            'Requested session not found. Has it been destroyed?', 400, e)
     except Exception as e:
         return process_error('Failed to query session', 500, e)
 


### PR DESCRIPTION
This PR adds its own exception type for a session not found error.

It also prints error details to the client console when an API query fails, for easier debugging (the server already strives to not reveal any sensitive information that it doesn't need to to the client and only send back a stripped-down useful context, so I'm printing the output as-is without further filtering).