### PR TITLE
Broadcast summaries to all; clean transcript every 15 seconds

### DIFF
--- a/client/components/AIAssistant.js
+++ b/client/components/AIAssistant.js
@@ -61,6 +61,15 @@ export const AIAssistant = ({ roomUrl }) => {
     }, []),
   );
 
+  useDailyEvent(
+    "network-connection",
+    useCallback((ev) => {
+      if (ev.type === "signaling" && ev.event === "connected") {
+        setTimeout(handleSummaryClick, 100)
+      }
+    }, [daily]),
+  );
+
   const playAudioMsg = () => {
     if (!audioMsgRef.current || !playSounds) return;
     audioMsgRef.current.currentTime = 0;
@@ -102,11 +111,14 @@ export const AIAssistant = ({ roomUrl }) => {
       daily.sendAppMessage({
         "kind": "assist",
         "task": "summary",
+        "broadcast": true,
       }, "*")
       playAudioMsg();
-    } catch {
+    } catch (e) {
+      console.error("Failed to request summary:", e)
       setSummary(summaryErrorText);
       playAudioError();
+      setIsSummarizing(false);
     } 
   };
 

--- a/client/components/AIAssistant.js
+++ b/client/components/AIAssistant.js
@@ -61,10 +61,13 @@ export const AIAssistant = ({ roomUrl }) => {
     }, []),
   );
 
+  const hasRequestedInitialSummary = useRef(false);
   useDailyEvent(
     "network-connection",
     useCallback((ev) => {
       if (ev.type === "signaling" && ev.event === "connected") {
+        if (hasRequestedInitialSummary.current) return;
+        hasRequestedInitialSummary.current = true;
         setTimeout(handleSummaryClick, 100)
       }
     }, [daily]),

--- a/client/pages/api/create-session.js
+++ b/client/pages/api/create-session.js
@@ -95,7 +95,7 @@ function getDailyAPIURL(roomURL) {
   if (hostParts.length > 3) {
     subdomain = `${hostParts[1]}.`
   }
-  return `https://${subdomain}api.daily.co/v1`
+  return `https://api.${subdomain}daily.co/v1`
 } 
 
 /**

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -126,11 +126,11 @@ class Session(EventHandler):
         want_cached_summary = not bool(custom_query)
         answer = None
 
-        # If we want a generic summary, and we have a cached one that's less than 30 seconds old,
+        # If we want a generic summary, and we have a cached one that's less than 15 seconds old,
         # just return that.
         if want_cached_summary and self._summary:
             seconds_since_generation = time.time() - self._summary.retrieved_at
-            if seconds_since_generation < 30:
+            if seconds_since_generation < 15:
                 self._logger.info("Returning cached summary")
                 answer = self._summary.content
 
@@ -176,7 +176,7 @@ class Session(EventHandler):
 
         # If this is a broadcast, set recipient to all participants
         if bool(data.get("broadcast")):
-            recipient = "*"
+            recipient = None
 
         task = data.get("task")
 
@@ -247,12 +247,12 @@ class Session(EventHandler):
             await asyncio.sleep(interval)
 
     def start_transcript_polling(self):
-        """Starts an asyncio event loop and schedules generate_clean_transcript to run every 30 seconds."""
+        """Starts an asyncio event loop and schedules generate_clean_transcript to run every 15 seconds."""
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         loop.run_until_complete(
             self.poll_async_func(
-                self._generate_clean_transcript, 30))
+                self._generate_clean_transcript, 15))
 
     # TODO: (Liza) Uncomment this when transcription events are properly invoked
     # if the transcription is starte before the bot joins.

--- a/server/call/session.py
+++ b/server/call/session.py
@@ -147,8 +147,12 @@ class Session(EventHandler):
                     self._summary = Summary(
                         content=answer, retrieved_at=time.time())
             except NoContextError:
-                answer = ("Sorry! I don't have any context saved yet. Please try speaking to add some context and "
+                answer = ("I don't have any context saved yet. Please speak to add some context or "
                           "confirm that transcription is enabled.")
+            except Exception as e:
+                self._logger.error(
+                    "Failed to query assistant: %s", e)
+                answer = ("Something went wrong while generating the summary. Please check the server logs.")
 
         return answer
 


### PR DESCRIPTION
This PR:

* Triggers transcript cleanup every 15 seconds instead of 30
* Caches previously generated summary for 15 seconds instead of 30
* Requests a new summary on meeting join
* Broadcasts summary to the entire call instead of just the sender
* Slightly modifies "no context" summary response to make it look like a less aggressive error (since at the beginning of a call it would be expected)